### PR TITLE
Dapper column attribute

### DIFF
--- a/laget.Db.Dapper.Tests/Extensions/DapperColumnAttributeTests.cs
+++ b/laget.Db.Dapper.Tests/Extensions/DapperColumnAttributeTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using laget.Db.Dapper.Extensions;
+using Xunit;
+
+namespace laget.Db.Dapper.Tests.Extensions
+{
+    public class DapperColumnAttributeTests
+    {
+        [Fact]
+        public void IsAttributeMultipleFalse()
+        {
+            var attributes = (IList<AttributeUsageAttribute>)typeof(DapperColumnAttribute).GetCustomAttributes(typeof(AttributeUsageAttribute), false);
+            Assert.Equal(1, attributes.Count);
+
+            var attribute = attributes[0];
+            Assert.False(attribute.AllowMultiple);
+        }
+
+        //[Fact]
+        //public void ShouldReturnCorrectTableName()
+        //{
+        //    const string expected = "intUserId";
+        //    var actual = new TestClass().TableName;
+
+        //    Assert.Equal(expected, actual);
+        //}
+
+        [DapperTable("tTable", "Table")]
+
+        public class TestClass : Entity
+        {
+            [DapperColumn("intUserId")]
+            public override int Id { get; set; }
+
+            public string TableName
+            {
+                get
+                {
+                    var attribute = (DapperTableAttribute)Attribute.GetCustomAttribute(typeof(TestClass), typeof(DapperTableAttribute));
+
+                    return attribute == null ? nameof(TestClass) : attribute.TableName;
+                }
+            }
+
+            public override object ToObject()
+            {
+                return new { };
+            }
+        }
+    }
+}

--- a/laget.Db.Dapper.Tests/Extensions/DapperColumnAttributeTests.cs
+++ b/laget.Db.Dapper.Tests/Extensions/DapperColumnAttributeTests.cs
@@ -16,37 +16,5 @@ namespace laget.Db.Dapper.Tests.Extensions
             var attribute = attributes[0];
             Assert.False(attribute.AllowMultiple);
         }
-
-        //[Fact]
-        //public void ShouldReturnCorrectTableName()
-        //{
-        //    const string expected = "intUserId";
-        //    var actual = new TestClass().TableName;
-
-        //    Assert.Equal(expected, actual);
-        //}
-
-        [DapperTable("tTable", "Table")]
-
-        public class TestClass : Entity
-        {
-            [DapperColumn("intUserId")]
-            public override int Id { get; set; }
-
-            public string TableName
-            {
-                get
-                {
-                    var attribute = (DapperTableAttribute)Attribute.GetCustomAttribute(typeof(TestClass), typeof(DapperTableAttribute));
-
-                    return attribute == null ? nameof(TestClass) : attribute.TableName;
-                }
-            }
-
-            public override object ToObject()
-            {
-                return new { };
-            }
-        }
     }
 }

--- a/laget.Db.Dapper.Tests/Models/AccountModel.cs
+++ b/laget.Db.Dapper.Tests/Models/AccountModel.cs
@@ -1,12 +1,17 @@
 ﻿using System;
+using laget.Db.Dapper.Extensions;
 
 namespace laget.Db.Dapper.Tests.Models
 {
     public class AccountModel : Entity
     {
+        [DapperColumn("intAccountId")]
+        public override int Id { get; set; } = 1;
         public string FirstName { get; set; } = "Jane";
         public string LastName { get; set; } = "Doe";
         public string Email { get; set; }
+        [DapperColumn("intAccountId")]
+        public string SocialSecurityNumber = "1986860320-5009";
 
         public AccountModel()
         {

--- a/laget.Db.Dapper.Tests/Models/AttributeTestModel.cs
+++ b/laget.Db.Dapper.Tests/Models/AttributeTestModel.cs
@@ -1,16 +1,21 @@
 ﻿using System;
+using laget.Db.Dapper.Extensions;
 
 namespace laget.Db.Dapper.Tests.Models
 {
-    public class TestModel : Entity
+    [DapperTable("Attributes")]
+    public class AttributeTestModel : Entity
     {
+        [DapperColumn("intId")]
+        public override int Id { get; set; }
         public string Column1 { get; set; }
         public bool Column2 { get; set; }
         public int Column3 { get; set; }
         public string Column4 { get; set; }
-        public virtual int? Column5 { get; set; }
+        [DapperColumn("Column6")]
+        public int? Column5 { get; set; }
 
-        public TestModel()
+        public AttributeTestModel()
         {
             Id = int.MaxValue;
             CreatedAt = DateTime.Now.AddMonths(-1);

--- a/laget.Db.Dapper.Tests/Models/TestModel.cs
+++ b/laget.Db.Dapper.Tests/Models/TestModel.cs
@@ -8,7 +8,7 @@ namespace laget.Db.Dapper.Tests.Models
         public bool Column2 { get; set; }
         public int Column3 { get; set; }
         public string Column4 { get; set; }
-        public virtual int? Column5 { get; set; }
+        public int? Column5 { get; set; }
 
         public TestModel()
         {

--- a/laget.Db.Dapper.Tests/RepositoryAttributeSqlTests.cs
+++ b/laget.Db.Dapper.Tests/RepositoryAttributeSqlTests.cs
@@ -5,11 +5,11 @@ using Xunit;
 
 namespace laget.Db.Dapper.Tests
 {
-    public class RepositorySqlTests : IClassFixture<RepositoryFixture<TestModel>>
+    public class RepositoryAttributeSqlTests : IClassFixture<RepositoryFixture<AttributeTestModel>>
     {
-        private readonly TestRepository<TestModel> _repository;
+        private readonly TestRepository<AttributeTestModel> _repository;
 
-        public RepositorySqlTests(RepositoryFixture<TestModel> fixture)
+        public RepositoryAttributeSqlTests(RepositoryFixture<AttributeTestModel> fixture)
         {
             _repository = fixture.Repository;
         }
@@ -17,7 +17,7 @@ namespace laget.Db.Dapper.Tests
         [Fact]
         public void GetInsertQueryGeneratesSql()
         {
-            var model = new TestModel
+            var model = new AttributeTestModel
             {
                 Column1 = "foo",
                 Column2 = true,
@@ -29,7 +29,7 @@ namespace laget.Db.Dapper.Tests
             var query = _repository.ExposedGetInsertQuery(model);
             dynamic parameters = query.parameters;
 
-            Assert.Equal("INSERT INTO [TestModel] ([Column1],[Column2],[Column3],[Column4],[Column5]) OUTPUT INSERTED.Id VALUES (@Column1,@Column2,@Column3,@Column4,@Column5)", query.sql);
+            Assert.Equal("INSERT INTO [Attributes] ([Column1],[Column2],[Column3],[Column4],[Column6]) OUTPUT INSERTED.intId VALUES (@Column1,@Column2,@Column3,@Column4,@Column6)", query.sql);
             Assert.Equal(model.Column1, parameters.Column1);
             Assert.Equal(model.Column2, parameters.Column2);
             Assert.Equal(model.Column3, parameters.Column3);
@@ -44,7 +44,7 @@ namespace laget.Db.Dapper.Tests
         [Fact]
         public void GetUpdateQueryGeneratesSql()
         {
-            var model = new TestModel
+            var model = new AttributeTestModel
             {
                 Id = 666,
                 Column1 = "foo",
@@ -57,35 +57,12 @@ namespace laget.Db.Dapper.Tests
             var query = _repository.ExposedGetUpdateQuery(model);
             dynamic parameters = query.parameters;
 
-            Assert.Equal("UPDATE [TestModel] SET [Column1] = @Column1, [Column2] = @Column2, [Column3] = @Column3, [Column4] = @Column4, [Column5] = @Column5 WHERE [Id] = @Id", query.sql);
+            Assert.Equal("UPDATE [Attributes] SET [Column1] = @Column1, [Column2] = @Column2, [Column3] = @Column3, [Column4] = @Column4, [Column6] = @Column6 WHERE [intId] = @Id", query.sql);
             Assert.Equal(model.Column1, parameters.Column1);
             Assert.Equal(model.Column2, parameters.Column2);
             Assert.Equal(model.Column3, parameters.Column3);
             Assert.Equal(model.Column4, parameters.Column4);
             Assert.Equal(model.Column5, parameters.Column5);
-        }
-
-        [Fact]
-        public void GetDeleteQueryGeneratesSql()
-        {
-            var model = new TestModel
-            {
-                Id = 666
-            };
-
-            var query = _repository.ExposedGetDeleteQuery(model);
-            dynamic parameters = query.parameters;
-
-            Assert.Equal("DELETE FROM [TestModel] WHERE Id = @Id", query.sql);
-            Assert.Equal(666, model.Id);
-        }
-
-        [Fact]
-        public void GetWhereQueryGeneratesSql()
-        {
-            var query = _repository.ExposedGetWhereQuery("Property = 0 AND Status = 1");
-
-            Assert.Equal("SELECT * FROM [TestModel] WHERE Property = 0 AND Status = 1", query);
         }
     }
 }

--- a/laget.Db.Dapper.Tests/RepositoryAttributeSqlTests.cs
+++ b/laget.Db.Dapper.Tests/RepositoryAttributeSqlTests.cs
@@ -29,7 +29,7 @@ namespace laget.Db.Dapper.Tests
             var query = _repository.ExposedGetInsertQuery(model);
             dynamic parameters = query.parameters;
 
-            Assert.Equal("INSERT INTO [Attributes] ([Column1],[Column2],[Column3],[Column4],[Column6]) OUTPUT INSERTED.intId VALUES (@Column1,@Column2,@Column3,@Column4,@Column6)", query.sql);
+            Assert.Equal("INSERT INTO [Attributes] ([Column1],[Column2],[Column3],[Column4],[Column6]) OUTPUT INSERTED.[intId] VALUES (@Column1,@Column2,@Column3,@Column4,@Column6)", query.sql);
             Assert.Equal(model.Column1, parameters.Column1);
             Assert.Equal(model.Column2, parameters.Column2);
             Assert.Equal(model.Column3, parameters.Column3);
@@ -63,6 +63,29 @@ namespace laget.Db.Dapper.Tests
             Assert.Equal(model.Column3, parameters.Column3);
             Assert.Equal(model.Column4, parameters.Column4);
             Assert.Equal(model.Column5, parameters.Column5);
+        }
+
+        [Fact]
+        public void GetDeleteQueryGeneratesSql()
+        {
+            var model = new AttributeTestModel
+            {
+                Id = 666
+            };
+
+            var query = _repository.ExposedGetDeleteQuery(model);
+            dynamic parameters = query.parameters;
+
+            Assert.Equal("DELETE FROM [Attributes] WHERE [intId] = @Id", query.sql);
+            Assert.Equal(666, model.Id);
+        }
+
+        [Fact]
+        public void GetWhereQueryGeneratesSql()
+        {
+            var query = _repository.ExposedGetWhereQuery("Property = 0 AND Status = 1");
+
+            Assert.Equal("SELECT * FROM [Attributes] WHERE Property = 0 AND Status = 1", query);
         }
     }
 }

--- a/laget.Db.Dapper.Tests/RepositorySqlTests.cs
+++ b/laget.Db.Dapper.Tests/RepositorySqlTests.cs
@@ -29,7 +29,7 @@ namespace laget.Db.Dapper.Tests
             var query = _repository.ExposedGetInsertQuery(model);
             dynamic parameters = query.parameters;
 
-            Assert.Equal("INSERT INTO [TestModel] ([Column1],[Column2],[Column3],[Column4],[Column5]) OUTPUT INSERTED.Id VALUES (@Column1,@Column2,@Column3,@Column4,@Column5)", query.sql);
+            Assert.Equal("INSERT INTO [TestModel] ([Column1],[Column2],[Column3],[Column4],[Column5]) OUTPUT INSERTED.[Id] VALUES (@Column1,@Column2,@Column3,@Column4,@Column5)", query.sql);
             Assert.Equal(model.Column1, parameters.Column1);
             Assert.Equal(model.Column2, parameters.Column2);
             Assert.Equal(model.Column3, parameters.Column3);
@@ -76,7 +76,7 @@ namespace laget.Db.Dapper.Tests
             var query = _repository.ExposedGetDeleteQuery(model);
             dynamic parameters = query.parameters;
 
-            Assert.Equal("DELETE FROM [TestModel] WHERE Id = @Id", query.sql);
+            Assert.Equal("DELETE FROM [TestModel] WHERE [Id] = @Id", query.sql);
             Assert.Equal(666, model.Id);
         }
 

--- a/laget.Db.Dapper/Entity.cs
+++ b/laget.Db.Dapper/Entity.cs
@@ -4,7 +4,7 @@ namespace laget.Db.Dapper
 {
     public abstract class Entity
     {
-        public int Id { get; set; }
+        public virtual int Id { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
 

--- a/laget.Db.Dapper/Extensions/DapperColumnAttribute.cs
+++ b/laget.Db.Dapper/Extensions/DapperColumnAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace laget.Db.Dapper.Extensions
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property)]
+    public class DapperColumnAttribute : Attribute
+    {
+        public virtual string ColumnName { get; }
+
+        public DapperColumnAttribute(string columnName)
+        {
+            ColumnName = columnName;
+        }
+    }
+}

--- a/laget.Db.Dapper/Repository.cs
+++ b/laget.Db.Dapper/Repository.cs
@@ -398,7 +398,7 @@ namespace laget.Db.Dapper
             var columns = string.Join(",", properties.Select(x => $"[{x}]"));
             var keys = string.Join(",", properties.Select(x => $"@{x}"));
 
-            var sql = $"INSERT INTO [{TableName}] ({columns}) OUTPUT INSERTED.{GetColumnName(entity, entity.GetType().GetMember("Id").FirstOrDefault())} VALUES ({keys})";
+            var sql = $"INSERT INTO [{TableName}] ({columns}) OUTPUT INSERTED.[{GetColumnName(entity, entity.GetType().GetMember("Id").FirstOrDefault())}] VALUES ({keys})";
 
             return (sql, obj);
         }
@@ -422,7 +422,7 @@ namespace laget.Db.Dapper
                 entity.Id
             };
 
-            var sql = $"DELETE FROM [{TableName}] WHERE Id = @Id";
+            var sql = $"DELETE FROM [{TableName}] WHERE [{GetColumnName(entity, entity.GetType().GetMember("Id").FirstOrDefault())}] = @Id";
 
             return (sql, obj);
         }


### PR DESCRIPTION
* Added `DapperColumnAttribute` to support custom column names
  * Supports `AttributeTargets.Field`, `AttributeTargets.Parameter` and `AttributeTargets.Property`
* We're now decorating each column with `[]` (e.g. `INSERTED.[Id]`)