### PR TITLE
LAGET-950 Move Get outside connection in Update and UpdateAsync

### DIFF
--- a/laget.Db.Dapper/Repository.cs
+++ b/laget.Db.Dapper/Repository.cs
@@ -203,23 +203,28 @@ namespace laget.Db.Dapper
         {
             var (sql, parameters) = GetInsertQuery(entity);
 
+            int id;
+
             using (var connection = new SqlConnection(ConnectionString))
             {
-                var id = (int)connection.ExecuteScalar(sql, parameters);
-                return Get(id);
+                id = (int)connection.ExecuteScalar(sql, parameters);
             }
+
+            return Get(id);
         }
 
         public virtual async Task<TEntity> InsertAsync(TEntity entity)
         {
             var (sql, parameters) = GetInsertQuery(entity);
 
+            int id;
+
             using (var connection = new SqlConnection(ConnectionString))
             {
-                var id = (int)await connection.ExecuteScalarAsync(sql, parameters);
-
-                return await GetAsync(id);
+                id = (int)await connection.ExecuteScalarAsync(sql, parameters);
             }
+
+            return await GetAsync(id);
         }
 
         public virtual void Insert(IEnumerable<TEntity> entities)

--- a/laget.Db.Dapper/Repository.cs
+++ b/laget.Db.Dapper/Repository.cs
@@ -284,8 +284,6 @@ namespace laget.Db.Dapper
                     {
                         connection.Execute(sql, entity, transaction);
                         transaction.Commit();
-
-                        return Get(entity.Id);
                     }
                     catch (Exception ex)
                     {
@@ -294,6 +292,8 @@ namespace laget.Db.Dapper
                     }
                 }
             }
+
+            return Get(entity.Id);
         }
 
         public virtual async Task<TEntity> UpdateAsync(TEntity entity)
@@ -310,8 +310,6 @@ namespace laget.Db.Dapper
                     {
                         await connection.ExecuteAsync(sql, entity, transaction);
                         transaction.Commit();
-
-                        return await GetAsync(entity.Id);
                     }
                     catch (Exception ex)
                     {
@@ -320,6 +318,8 @@ namespace laget.Db.Dapper
                     }
                 }
             }
+
+            return await GetAsync(entity.Id);
         }
 
         public void Update(IEnumerable<TEntity> entities)


### PR DESCRIPTION
Vi behöver flytta ut Get & GetAsync utanför Connection om Update eller UpdateAsync anropet ligger inuti ett TransactionScope. Detta för att vi inte kan ha samma transaction över två Connections